### PR TITLE
Update go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.7
-    - go: 1.8
-    - go: tip
+    - 1.9.2
+    - 1.8.5
 
 install:
   - # Skip


### PR DESCRIPTION
This should resolve issue #5 relating to failing builds.

We should be following the go versions machinery supports only so as to note break any builds.